### PR TITLE
[secure boot]Fix mokutil check issue with ONIE version older than 202…

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -435,13 +435,20 @@ bootloader_menu_config()
         mv $onie_initrd_tmp/tmp/onie-support*.tar.bz2 $demo_mnt/$image_dir/
 
         if [ "$firmware" = "uefi" ] ; then
-            secure_boot_state=$(mokutil --sb-state)
+            reg_sb_guid=$(efivar -l | grep "SecureBoot")
+            secure_boot_state=""
+            if echo "$reg_sb_guid" | grep -q "SecureBoot";then
+                secure_boot_state=$(efivar -d --name $reg_sb_guid)
+            else
+                echo "Current UEFI do not support Secure Boot feature"
+                secure_boot_state="0"
+            fi
             echo secure_boot_state=$secure_boot_state
-            if [ "$secure_boot_state" = "SecureBoot enabled" ]; then
-                echo "UEFI Secure Boot is enabled"
+            if [ "$secure_boot_state" -eq 1 ]; then
+                echo "UEFI Secure Boot is enabled - Installing shim bootloader"
                 demo_install_uefi_shim "$demo_mnt" "$blk_dev"
             else
-                echo "UEFI Secure Boot is disabled"
+                echo "UEFI Secure Boot is disabled - installing regular grub bootloader"
                 demo_install_uefi_grub "$demo_mnt" "$blk_dev"
             fi
         else


### PR DESCRIPTION
…1.11 by using efivar tool instead

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

